### PR TITLE
docs: Add ADRs to template

### DIFF
--- a/docs/adrs/0000-use-markdown-any-decision-records copy.md
+++ b/docs/adrs/0000-use-markdown-any-decision-records copy.md
@@ -1,0 +1,27 @@
+# Use Markdown Any Decision Records
+
+## Context and Problem Statement
+
+We want to record any decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields.
+Which format and structure should these records follow?
+
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 3.0.0-beta – The Markdown Any Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* Formless – No conventions for file format and structure
+
+## Decision Outcome
+
+Chosen option: "MADR 3.0.0-beta", because
+
+* Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions later on.
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+* MADR allows for structured capturing of any decision.
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.
+* It is supported out of the box by Operate First service catalog of choice - Backstage.

--- a/docs/adrs/0001-create-github-applications-with-probot-and-tekton.md
+++ b/docs/adrs/0001-create-github-applications-with-probot-and-tekton.md
@@ -1,0 +1,59 @@
+# Create Github applications with Probot and Tekton
+
+## Context and Problem Statement
+
+We want to create a generic GitHub bot factory that is workload agnostic, cloud native and easy to develop. Historically we've explored various options. This ADR should serve as a baseline for a number of bots which can share the same basic architecture and layout.
+
+## Decision Drivers
+
+* Bot is cloud-compatible, it is possible to easily deploy it on Kubernetes, it scales.
+* Bot is primarily targeting GitHub integration.
+* Bot is easy to develop. Developer experience matters, especially when integrating with third party services like GitHub. Decision outcome should make it easy for developers to work in sandbox diverse environments (partially) behind VPN.
+* Release process is easy to streamline and gitopsify.
+
+## Considered Options
+
+* Tekton and Tekton Triggers
+* Probot controller with Tekton
+* Standalone Probot controller
+
+## Decision Outcome
+
+Chosen options: "Probot controller with Tekton".
+
+### Positive Consequences
+
+This is a hybrid solution of a controller service being developed as a cloud deployed application via Probot with a cloud native Tekton counterpart for heavy lifting.
+
+Probot provides great GitHub integration capabilities and since it's developed as an application, it can be run both locally on developer machine as well as deployed to Kubernetes.
+
+Tekton provides cloud native task execution environment, allowing on demand, potentially resource heavy computation within cloud allowing bot developer to use diverse external tools as external dependencies via containerized task runners - each task can pack and execute different containers.
+
+```mermaid
+flowchart LR
+    gh[GitHub] -- Webhook events trigger --> c[Probot app controller]
+    c -- Auth requests --> gh
+    c -- Store/fetch secret --> k[Kubernetes API]
+    c -- Schedule task --> k[Kubernetes API]
+```
+
+Combination of a Probot application with Tekton allows great developer experience when the controller is easy to run locally while Tekton tasks can be scheduled to locally connected Kubernetes cluster which can be behind VPN.
+
+### Negative Consequences
+
+Application maintenance is effectively split between code (Probot controller source code) and configuration (Tekton task manifests). These needs to be kept in sync in task naming and parameters aspects. API changes (changing parameters, task names) needs to be coordinated when releasing.
+
+## Pros and Cons of other Options
+
+### Tekton and Tekton Triggers
+
+* Good, because this option is fully cloud native meaning everything is orchestrated by Kuberentes and all handling is stored in Tekton manifests as configuration.
+* Good, simple releasing/gating process since everything is configuration which can be managed by git ops.
+* Bad, because fully cloud native solutions are complex to develop and debug. Since public GitHub interactions are primary target, development on private clusters behind VPN is not straightforward.
+* Bad, because integrations are hard to test without complex infrastructure.
+
+### Standalone Probot controller
+
+* Good, because GitHub integration works out of the box.
+* Good, because it's cloud compatible.
+* Bad, because everything has to be bundled into a single container which limits integration capabilities with various external tools necessary for heavy lifting.

--- a/docs/adrs/0002-use-shared-libraries.md
+++ b/docs/adrs/0002-use-shared-libraries.md
@@ -1,0 +1,18 @@
+# Use Shared Libraries
+
+## Context and Problem Statement
+
+This framework wants to support many different bots created from the same template. We need to have a way to unify how the bot accesses Kubernetes, exposes metrics etc.
+
+## Considered Options
+
+* Provide the shared code as part of the template
+* Extract code into modules published as npm packages
+
+## Decision Outcome
+
+Chosen option: "Extract code into modules published as npm packages", because
+
+* It allows us to release each module independently.
+* It is easier for individual bot creators to mix and match what integrations they need.
+* Syncing changes from template repositories into descendants can be complex issue compared to npm dependency package upgrades locally.


### PR DESCRIPTION
Add ADR for:
- Use ADRs
- Use Probot and Tekton
- Use shared packages from probot-extensions